### PR TITLE
chore: enable Renovate security updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,7 +32,7 @@
       "matchJsonata": [
         "$exists(vulnerabilityFixVersion)"
       ],
-      "labels": [
+      "addLabels": [
         "security"
       ],
       "automerge": false
@@ -40,7 +40,7 @@
   ],
   "osvVulnerabilityAlerts": true,
   "vulnerabilityAlerts": {
-    "labels": [
+    "addLabels": [
       "security"
     ],
     "automerge": false,

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,12 +1,49 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", "helpers:pinGitHubActionDigests", "group:allNonMajor"],
-  "labels": ["Meta: Dependencies"],
-  "schedule": ["before 12pm on Sunday"],
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    "group:allNonMajor",
+    ":enableVulnerabilityAlerts"
+  ],
+  "labels": [
+    "Meta: Dependencies"
+  ],
+  "schedule": [
+    "before 12pm on Sunday"
+  ],
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "digest"
+      ],
       "automerge": true
+    },
+    {
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    },
+    {
+      "matchJsonata": [
+        "$exists(vulnerabilityFixVersion)"
+      ],
+      "labels": [
+        "security"
+      ],
+      "automerge": false
     }
-  ]
+  ],
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ],
+    "automerge": false,
+    "vulnerabilityFixStrategy": "lowest"
+  }
 }


### PR DESCRIPTION
## Summary

- Enables Renovate vulnerability-alert PRs sourced from GitHub Dependabot alerts.
- Enables OSV scanning as a supplemental source for supported direct dependencies.
- Labels vulnerability-fix PRs `security` and disables automerge for them.
- Prefers the lowest patched version to minimize compatibility risk.
- Explicitly disables automerge for major updates.
- Preserves the repository's existing Renovate rules; deprecated `config:base` references are migrated to `config:recommended` where present.

## Validation

- JSON parsing passed.
- `renovate-config-validator` from Renovate 43.275.0 passed.
- `git diff --check` passed.
- This is configuration-only; repository code and dependency lockfiles are unchanged.

## Security sources

- **Primary advisory source:** GitHub Dependabot alerts (Renovate reads alerts; Dependabot alerts remain open).
- **Supplemental source:** OSV via `osvVulnerabilityAlerts` (supported direct dependencies only).

## Manual follow-up

- Renovate is already active in this repository. Confirm the Renovate App installation now lists **Dependabot alerts: read**; GitHub does not expose that installation permission through the current `gh` OAuth token.
- After the next Renovate run, verify that vulnerability PRs carry the `security` label and are not automerged.
- Do not enable duplicate Dependabot security-update PR generation once Renovate security PR creation is proven. Existing Dependabot security updates were not disabled in this change to avoid a coverage gap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Renovate security PRs from `Dependabot` and OSV. Label them `security`, block automerge, prefer the lowest patch, and switch to `config:recommended` while preserving current rules and labels.

- **New Features**
  - Enable security PRs via `:enableVulnerabilityAlerts` and `osvVulnerabilityAlerts: true` (sources: `Dependabot` + OSV).
  - Label vulnerability PRs `security`, set `automerge: false`, and use `vulnerabilityFixStrategy: lowest`.
  - Disable automerge for `major` updates.
  - Migrate to `config:recommended`; retain `group:allNonMajor`, `helpers:pinGitHubActionDigests`, and existing labels.

<sup>Written for commit acef84d8c6e9493366b41f8921eeba8c1918d844. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/TurboCheetah/ts-boilerplate/pull/304?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

